### PR TITLE
Return observed devices after established connection

### DIFF
--- a/src/Tradfri.coffee
+++ b/src/Tradfri.coffee
@@ -76,7 +76,8 @@ class Tradfri extends Property
           .then =>
             console.log "observeGroupsAndScenes resolved" if @debug
             @connectState = States.CONNECTED
-            credentials
+            credentials: credentials
+            devices: Accessory.devices
         when States.CONNECTING
           await sleep .25 until @connectState is States.CONNECTED
     .finally =>


### PR DESCRIPTION
With this pull request the observed devices will be returned in addition to the credentials after establishing the connection.
Please advice if there is another proposed way to retrieve a list of devices.